### PR TITLE
Fix duplicate video routes

### DIFF
--- a/lib/hello_web/router.ex
+++ b/lib/hello_web/router.ex
@@ -29,7 +29,7 @@ defmodule HelloWeb.Router do
   #   pipe_through :api
   # end
 
-  scope "/manage", HelloWeb do
+  scope "/manage", HelloWeb, as: :manage do
     pipe_through [:browser, :authenticate_user]
     resources "/videos", VideoController
   end


### PR DESCRIPTION
See https://hexdocs.pm/phoenix/routing.html#scoped-routes

You get

```
       video_path  GET     /videos                  HelloWeb.VideoController :index
       video_path  GET     /videos/:id/edit         HelloWeb.VideoController :edit
       video_path  GET     /videos/new              HelloWeb.VideoController :new
       video_path  GET     /videos/:id              HelloWeb.VideoController :show
       video_path  POST    /videos                  HelloWeb.VideoController :create
       video_path  PATCH   /videos/:id              HelloWeb.VideoController :update
       video_path  DELETE  /videos/:id              HelloWeb.VideoController :delete

manage_video_path  GET     /manage/videos           HelloWeb.VideoController :index
manage_video_path  GET     /manage/videos/:id/edit  HelloWeb.VideoController :edit
manage_video_path  GET     /manage/videos/new       HelloWeb.VideoController :new
manage_video_path  GET     /manage/videos/:id       HelloWeb.VideoController :show
manage_video_path  POST    /manage/videos           HelloWeb.VideoController :create
manage_video_path  PATCH   /manage/videos/:id       HelloWeb.VideoController :update
manage_video_path  DELETE  /manage/videos/:id       HelloWeb.VideoController :delete
```